### PR TITLE
Introduce a setter and getter

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,61 @@
+//! Implements a crossword puzzle container
+
 use ndarray::prelude::*;
 
+use std::convert::From;
 use std::fmt;
-use std::ops::Range;
+use std::ops::{Index, Range};
+use std::string::String;
 
 type Square = Option<char>;
 
-#[derive(Debug)]
+/// A read-only view of a crossword slot
+///
+/// This needs to be a newly defined type so that we can implement the From trait for
+/// ergonomic string conversions
+pub struct Slot<'a> {
+    view: ArrayView1<'a, Square>,
+}
+
+impl Slot<'_> {
+    pub fn len(&self) -> usize {
+        self.view.len()
+    }
+}
+
+impl Index<usize> for Slot<'_> {
+    type Output = char;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        if let Some(ref index) = self.view[index] {
+            index
+        } else {
+            panic!("A slot instance should not hold an empty Square");
+        }
+    }
+}
+
+impl From<Slot<'_>> for String {
+    fn from(item: Slot) -> String {
+        String::from_iter(item.view.iter().map(|elem| -> char {
+            if let Some(chr) = elem {
+                *chr
+            } else {
+                panic!("A slot instance should not hold an empty Square");
+            }
+        }))
+    }
+}
+
+/// used internally within a struct
+#[derive(Clone, Debug)]
 struct SlotCoords {
     r: Range<usize>, // starting and stopping coordinate along slice axis
     k: usize,        // row / col the slot is in
 }
 
-#[derive(Debug)]
+/// Abstracts the puzzle
+#[derive(Clone, Debug)]
 pub struct Puzzle {
     grid: Array2<Square>,
     downs: Vec<SlotCoords>,
@@ -76,6 +120,62 @@ impl Puzzle {
             downs,
         }
     }
+
+    /// Get the number of across-slots
+    pub fn nacross(&self) -> usize {
+        self.acrosses.len()
+    }
+
+    /// Get number of down-slots
+    pub fn ndown(&self) -> usize {
+        self.downs.len()
+    }
+
+    pub fn nslots(&self) -> usize {
+        self.nacross() + self.ndown()
+    }
+
+    /// returns a read-only view of a crossword slot
+    pub fn access(&self, i: usize) -> Slot {
+        if i < self.nacross() {
+            let coords: &SlotCoords = &self.acrosses[i];
+            Slot {
+                view: self.grid.slice(s![coords.k, coords.r.clone()]),
+            }
+        } else if i < self.nslots() {
+            let coords: &SlotCoords = &self.downs[i - self.nacross()];
+            Slot {
+                view: self.grid.slice(s![coords.r.clone(), coords.k]),
+            }
+        } else {
+            panic!("The index is too large!");
+        }
+    }
+
+    /// creates a new copy with a filled in puzzle
+    ///
+    /// This interface provides the desired CoW semantics (even if we don't
+    /// currently take advantage of them)
+    pub fn with_filled_slot(&self, i: usize, value: &str) -> Self {
+        let mut copy = self.clone();
+        // this could be more efficient
+        if value.chars().count() != copy.access(i).len() {
+            panic!("value doesn't have the correct length");
+        }
+
+        let mut view = if i < self.nacross() {
+            let coords: &SlotCoords = &copy.acrosses[i];
+            copy.grid.slice_mut(s![coords.k, coords.r.clone()])
+        } else {
+            let coords: &SlotCoords = &self.downs[i - self.nacross()];
+            copy.grid.slice_mut(s![coords.r.clone(), coords.k])
+        };
+
+        for (j, chr) in value.char_indices() {
+            view[j] = Some(chr);
+        }
+        copy
+    }
 }
 
 fn fmt_squares<'a, I>(f: &mut fmt::Formatter<'_>, squares: I, indent: Option<&str>) -> fmt::Result
@@ -115,5 +215,59 @@ impl fmt::Display for Puzzle {
         write!(f, "}}")?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Puzzle;
+
+    #[test]
+    fn basic() {
+        let crossword_str = "\
+.ABC.
+DE.FG
+TROUT
+.MNO.\
+";
+
+        let puzzle = Puzzle::from_str(crossword_str);
+
+        let across_vals = ["ABC", "DE", "FG", "TROUT", "MNO"];
+        let down_vals = ["DT", "AERM", "B", "ON", "CFUO", "GT"];
+        assert_eq!(puzzle.nacross(), across_vals.len());
+        assert_eq!(puzzle.ndown(), down_vals.len());
+
+        let ref_vals = Vec::from_iter(
+            across_vals
+                .iter()
+                .chain(down_vals.iter())
+                .map(|s| s.to_string()),
+        );
+        assert_eq!(puzzle.nslots(), ref_vals.len());
+
+        for i in 0..puzzle.nslots() {
+            assert_eq!(String::from(puzzle.access(i)), ref_vals[i]);
+        }
+
+        // we are going to modify modify_index so that it now holds "XY"
+        let modify_index = puzzle.nslots() - 1;
+        let new_val = "XY";
+        let mut modified_ref_vals = ref_vals.clone();
+        modified_ref_vals[2] = String::from("FX");
+        modified_ref_vals[3] = String::from("TROUY");
+        modified_ref_vals[modify_index] = new_val.to_string();
+
+        let modified = puzzle.with_filled_slot(modify_index, &new_val);
+
+        // ensure the original wasn't modified
+        for i in 0..puzzle.nslots() {
+            assert_eq!(String::from(puzzle.access(i)), ref_vals[i]);
+        }
+
+        // ensure the modified puzzle has the updated values
+        for i in 0..modified.nslots() {
+            assert_eq!(String::from(modified.access(i)), modified_ref_vals[i]);
+        }
     }
 }


### PR DESCRIPTION
This commit primarily introduces a setter and getter for Puzzle

Here is a basic summary of my thought-process (@ajwheeler feel free to challenge/criticize/question anything)

For a puzzle, `puz`, the getter is implemented by `puz.access(i)`
  - the method's argument, `i`, is a scalar index and returns a read-only view of a slot
  - right now, `i < puz.nacross()` will return an "across-slot" and `puz.nacross() <= i < puz.nslots()` returns a "down-slot"
  - originally, I thought about making some kind of enum so we could specify down-1 and across-2, etc. But, I think I we should hold of on doing something like that.
    - Frankly, it seems a little cumbersome where we have slots labelled like Down-1, Down-2, Down-3, Down-7, ... and Across-1, Across-3. Across-4, Across-5, ...
    - ultimately, we probably want to support something like this, but I was thinking we could deal with that stuff later (I think it would be easier for the setter to just deal with a 1D slot-index).
  - To simplify the process of testing the `puz.access` method, I had it return a custom type `Slot`
    - Ideally, it would have just returned an `ArrayView<'a, Square>`, but it was tricky to coerce this to a `String` for testing purposes
    - To use standard techniques for string-coercion I needed to define a custom type (otherwise, the compiler wouldn't let me define the `From` trait)
    - I also added the `Index` trait to `Slot` (to support array-like access, `slot[j]`) and a method to access the slot's length (`slot.len()`)
  - afaict, `puz[i]` can **NOT** be supported unless it returned a reference (which we can't do right now)

For a puzzle, `puz`, the setter is implemented by `puz.with_filled_slot(i, val)`.
  - This returns a new copy of `puz` where slot `i` has been overwritten so that the new copy is equal to the `str` specified by the `val` argument
  - While this achieves our desired CoW semantics, this is currently expensive. The goal was to try to achieve the desired interface and then we can clean up the internals later on

At this point, we are probably ready to implement the setter's algorithm