### PR TITLE
Safer `Puzzle::from_str`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,8 +82,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
 name = "xw"
 version = "0.1.0"
 dependencies = [
  "ndarray",
+ "unicode-segmentation",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2021"
 
 [dependencies]
 ndarray = "0.16.1"
+unicode-segmentation = "1.10.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,6 +118,7 @@ impl Puzzle {
     /// and report an error.
     pub fn from_str(s: &str) -> Result<Puzzle, &'static str> {
         let v: Vec<&str> = s.split('\n').collect();
+        // true to use extended, as opposed to legacy grapheme clusters
         let ncols = v[0].graphemes(true).count();
         let nrows = v.len();
         let mut grid = Array::from_elem((nrows, ncols), None);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 //! Implements a crossword puzzle container
 
 use ndarray::prelude::*;
+use unicode_segmentation::UnicodeSegmentation;
 
 use std::convert::From;
 use std::fmt;
@@ -98,27 +99,62 @@ impl Puzzle {
         (acrosses, downs)
     }
 
-    pub fn from_str(s: &str) -> Puzzle {
+    /// Construct a Puzzle from a string view
+    ///
+    /// #Note About Grapheme Clusters
+    /// [grapheme clusters](https://www.unicode.org/reports/tr29/#Grapheme_Cluster_Boundaries)
+    /// are a subtle aspect of unicode.
+    /// - in short, a "user-perceived character" may correspond to a cluster
+    ///   of one or more unicode characters.
+    /// - As I understand it, you can think of most of these characters as
+    ///   "modifiers" (I believe a g with grave-accent is a "g" followed by a
+    ///   grave-modifier character). BE AWARE: This mental model may not apply
+    ///   for some characters used to represent non-latin-alphabet languages.
+    /// - In any case, a grapheme cluster is an approximation for these
+    ///   clusters of letters
+    ///
+    /// In the future, a crossword puzzle should fully support arbitrary
+    /// grapheme clusters. For now, this constructor, will parse the cluster,
+    /// and report an error.
+    pub fn from_str(s: &str) -> Result<Puzzle, &'static str> {
         let v: Vec<&str> = s.split('\n').collect();
-        let ncols = v[0].len();
+        let ncols = v[0].graphemes(true).count();
         let nrows = v.len();
         let mut grid = Array::from_elem((nrows, ncols), None);
 
         for i in 0..nrows {
-            for (j, chr) in v[i].char_indices() {
-                grid[[i, j]] = match chr {
-                    '.' => None,
-                    other => Some(other),
+            let mut j = 0;
+            let mut it = UnicodeSegmentation::graphemes(v[i], true);
+            while let Some(grapheme) = it.next() {
+                if j == ncols {
+                    // with custom error types, we coud be more descriptive
+                    return Err("a row has too many characters");
                 }
+
+                let mut inner_it = grapheme.chars();
+                // based on my understanding of invariants, the following never panics!
+                let chr = inner_it.next().unwrap();
+                if let Some(_dummy) = inner_it.next() {
+                    return Err("crossword puzzle can't contain a grapheme cluster composed of more than 1 unicode character");
+                } else {
+                    grid[[i, j]] = match chr {
+                        '.' => None,
+                        other => Some(other),
+                    }
+                }
+                j += 1;
+            }
+            if j != ncols {
+                return Err("a row has too few characters");
             }
         }
 
         let (acrosses, downs) = Puzzle::identify_slots(&grid);
-        Puzzle {
+        Ok(Puzzle {
             grid,
             acrosses,
             downs,
-        }
+        })
     }
 
     /// Get the number of across-slots
@@ -223,6 +259,36 @@ mod tests {
     use super::Puzzle;
 
     #[test]
+    fn puzzle_creation_errors() {
+        let too_few_chars = "\
+.ABC.
+DE.F\
+";
+        assert!(
+            Puzzle::from_str(too_few_chars).is_err(),
+            "too few characters in the second row"
+        );
+
+        let too_many_chars = "\
+.ABC.
+DE.FGH\
+";
+        assert!(
+            Puzzle::from_str(too_many_chars).is_err(),
+            "too few characters in the second row"
+        );
+
+        let multi_character_grapheme = "\
+.a̐BC.
+DE.FG\
+";
+        assert!(
+            Puzzle::from_str(multi_character_grapheme).is_err(),
+            "can't currently handle a multi-character grapheme cluster"
+        );
+    }
+
+    #[test]
     fn basic() {
         let crossword_str = "\
 .ABC.
@@ -231,7 +297,7 @@ TROUT
 .MNO.\
 ";
 
-        let puzzle = Puzzle::from_str(crossword_str);
+        let puzzle = Puzzle::from_str(crossword_str).unwrap();
 
         let across_vals = ["ABC", "DE", "FG", "TROUT", "MNO"];
         let down_vals = ["DT", "AERM", "B", "ON", "CFUO", "GT"];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,8 +124,7 @@ impl Puzzle {
 
         for i in 0..nrows {
             let mut j = 0;
-            let mut it = UnicodeSegmentation::graphemes(v[i], true);
-            while let Some(grapheme) = it.next() {
+            for grapheme in UnicodeSegmentation::graphemes(v[i], true) {
                 if j == ncols {
                     // with custom error types, we coud be more descriptive
                     return Err("a row has too many characters");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
+use std::error::Error;
 use xw::*;
 
-fn main() {
+fn main() -> Result<(), Box<dyn Error>> {
     let crossword_str = "\
 .ABC..asdf
 DE FG.asdf
@@ -8,9 +9,11 @@ TROUT.asdf
 .MNO..asdf\
 ";
 
-    let puzzle = Puzzle::from_str(crossword_str);
+    let puzzle = Puzzle::from_str(crossword_str)?;
 
     println!("This is our puzzle: {puzzle}");
+
+    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Should be reviewed and merged after #6 (the 1st commit comes from #6 and the 2nd commit is new to this PR)

Essentially, this adds some error checking so we can properly report errors in the `Puzzle::from_str` function.
- we now report when rows of a string have different numbers of characters
- as part of this, I learned a little more about unicode. It turns out the issue we previously saw when we passed in a Unicode character pertains to [grapheme clusters](https://www.unicode.org/reports/tr29/#Grapheme_Cluster_Boundaries).

### Quick Intro to Grapheme Clusters

For a quick overview, consider a *user-perceived character* in a language written with the latin alphabet
- this could be represented by a single unicode character (which itself is 1-4 bytes)
- or it could be represented by a cluster 1 or more unicode characters. The latter characters act like modifiers.
   - For example: a `g` character with the grave-accent would be 2 Unicode characters: `'g'` followed by `'◌̀'`
   - for concreteness the number of bytes, $N_{bytes}$, needed to encode a `user-perceived character` composed of $n_{char}$ Unicode-characters satisfies: $n_{char} \leq N_{bytes} \leq 4 n_{char}$
 - a cluster of 1 or more characters that correspond to a "user-perceived character" is approximated by a "grapheme cluster."

I haven't read the linked Unicode reference carefully. But, it sounds like in some cases, the definition of a _user-perceived character_ may depend on context (hence why they claim a Grapheme Cluster "approximates" a _user perceived character_). But, I don't think that's an issue for English or any language using the Latin alphabet.

I made changes to report an error when `Puzzle::from_str` encounters a grapheme clusters composed of 1 or more character. We can't currently represent a grapheme cluster in a crossword, but that's something we probably want to consider for the future[^1]

Aside: apparently, rust originally had built-in support for grapheme-clusters, but the maintainers decided to remove it (because the tables needed to support it can be large) so I needed to add a dependency on the [unicode-segmentation crate](https://crates.io/crates/unicode-segmentation), which very lightweight and is the de-facto standard (over 1e8 downloads)

[^1]: Technically, there is no upper bound to the size of a grapheme cluster, but we could probably set one for our purposes (or we could do something more flexible)